### PR TITLE
update intersect1d to have common points

### DIFF
--- a/numpy/lib/arraysetops.py
+++ b/numpy/lib/arraysetops.py
@@ -360,8 +360,8 @@ def intersect1d(ar1, ar2, assume_unique=False, return_indices=False):
         val2 = np.where(arr2 == commvals[i])[0][0]
         first.append(val1)
         second.append(val2)
-      comm1 =np.reshape(np.array(first),-1)
-      comm2 = np.reshape(np.array(second),-1)111
+      comm1 = np.reshape(np.array(first),-1)
+      comm2 = np.reshape(np.array(second),-1)
       return aux[:-1][aux[1:] == aux[:-1]],comm1,comm2
     return aux[:-1][aux[1:] == aux[:-1]]
 


### PR DESCRIPTION
Added a keyword argument 'return_indices' to np.intersect1d which returns the indices of the commonly shared points between the two input arrays in np.intersect1d.
This is a revision of an earlier pull request : https://github.com/numpy/numpy/pull/10683